### PR TITLE
setting CallbackContext for when memory closes parent activity

### DIFF
--- a/src/android/com/synconset/ImagePicker/ImagePicker.java
+++ b/src/android/com/synconset/ImagePicker/ImagePicker.java
@@ -11,7 +11,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
-
+import android.os.Bundle;
 import android.app.Activity;
 import android.content.Intent;
 import android.util.Log;
@@ -69,4 +69,8 @@ public class ImagePicker extends CordovaPlugin {
 			this.callbackContext.error("No images selected");
 		}
 	}
+
+  public void onRestoreStateForActivityResult(Bundle state, CallbackContext callbackContext) {
+    this.callbackContext = callbackContext;
+  }
 }


### PR DESCRIPTION
When parent activity is garbage collect by Android OS we need to get the CallbackContext.  this event: `onRestoreStateForActivityResult` allow us to do that. Otherwise a null pointer exception is raised causing the app to crash.